### PR TITLE
Use full URL when linking to RSS feed

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,7 +18,7 @@ const { frontmatter } = Astro.props;
       rel="alternate"
       type="application/rss+xml"
       title="Steve Klabnik"
-      href="/feed.xml"
+      href="https://steveklabnik.com/feed.xml"
     />
     <title>{frontmatter.pageTitle}</title>
   </head>


### PR DESCRIPTION
This is the only thing I can think of with #44; netnewswire claims to be able to follow the rel=alternate.

Fixes #44