### PR TITLE
Fix redundant await in feed generator

### DIFF
--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -5,7 +5,7 @@ import MarkdownIt from "markdown-it";
 const parser = new MarkdownIt();
 
 export async function GET(context) {
-  const posts = await await getCollection("blog");
+  const posts = await getCollection("blog");
   const items = posts
     .sort((a, b) => b.data.pubDate - a.data.pubDate)
     .map((post) => ({


### PR DESCRIPTION
## Summary
- remove redundant `await` when fetching blog posts for RSS feed

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7b5e458832993f272e74b2cbe81