### PR TITLE
Fix typo: receive

### DIFF
--- a/src/content/blog/run-rails-with-custom-patches.md
+++ b/src/content/blog/run-rails-with-custom-patches.md
@@ -5,7 +5,7 @@ blog: literate-programming
 ---
 
 
-I often see comments [like this](https://github.com/rails/rails/pull/7397#issuecomment-9132009) in the Rails bugtracker. Generally, someone is running an older version of Rails, and some bug they face has been fixed on edge. But they may be running a version that’s too old to recieve fixes, or need a fix that has yet to be included in an actual release. What to do?
+I often see comments [like this](https://github.com/rails/rails/pull/7397#issuecomment-9132009) in the Rails bugtracker. Generally, someone is running an older version of Rails, and some bug they face has been fixed on edge. But they may be running a version that’s too old to receive fixes, or need a fix that has yet to be included in an actual release. What to do?
 
 Luckily, [Bundler](http://gembundler.com/) exists. It makes it super easy to run your own Rails. Check it out:
 


### PR DESCRIPTION
## Summary
- fix spelling of "receive" in run-rails-with-custom-patches blog post

## Testing
- `grep -Ri "recieve" -n --exclude-dir=node_modules`


------
https://chatgpt.com/codex/tasks/task_e_683fb8d3edd08329b2fb393e4acb3205