### PR TITLE
Fix outdated link component comment

### DIFF
--- a/src/components/Link.jsx
+++ b/src/components/Link.jsx
@@ -1,4 +1,4 @@
-// for legacy reasons, this is also in global.css. 
+// Additional link styling (underline, visited color) lives in global.css
 export default function Link({ text, href }) {
   return (
     <a className="text-blue-500" href={href}>{ text }</a>


### PR DESCRIPTION
## Summary
- update Link component comment to clarify that global styles handle underline and visited color

## Testing
- `npm run build` *(fails: fetch failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_683fb8d596388329b099462d6b086ef6