### PR TITLE
render mdx in rss feed

### DIFF
--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -1,22 +1,30 @@
 import rss from "@astrojs/rss";
-import { getCollection } from "astro:content";
-import sanitizeHtml from "sanitize-html";
-import MarkdownIt from "markdown-it";
-const parser = new MarkdownIt();
+import { getCollection, render } from "astro:content";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getContainerRenderer as getMDXRenderer } from "@astrojs/mdx";
+import { loadRenderers } from "astro:container";
 
 export async function GET(context) {
+  const renderers = await loadRenderers([getMDXRenderer()]);
+  const container = await AstroContainer.create({ renderers });
+
   const posts = await getCollection("blog");
-  const items = posts
-    .sort((a, b) => b.data.pubDate - a.data.pubDate)
-    .map((post) => ({
-      title: post.data.title,
-      pubDate: post.data.pubDate,
-      description: post.data.description,
-      link: `/writing/${post.slug}/`,
-      content: sanitizeHtml(parser.render(post.body), {
-        allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+
+  const items = await Promise.all(
+    posts
+      .sort((a, b) => b.data.pubDate - a.data.pubDate)
+      .map(async (post) => {
+        const { Content } = await render(post);
+
+        return {
+          title: post.data.title,
+          pubDate: post.data.pubDate,
+          description: post.data.description,
+          link: `/writing/${post.slug}/`,
+          content: await container.renderToString(Content),
+        };
       }),
-    }));
+  );
 
   return rss({
     title: "Steve Klabnik",


### PR DESCRIPTION
uses astro container sandbox to pre-render mdx to html on build. fixes #103 

I did briefly check the feed.xml: 
```
<item>
<title>A tale of two Claudes</title>
<link>
https://steveklabnik.com/writing/a-tale-of-two-claudes/
</link>
<guid isPermaLink="true">
https://steveklabnik.com/writing/a-tale-of-two-claudes/
</guid>
<pubDate>Tue, 10 Jun 2025 00:00:00 GMT</pubDate>
<content:encoded>
<blockquote> <p>It was the best of times, it was the worst of times
```