### PR TITLE
Convert Buck/Rust posts to use native series functionality

### DIFF
--- a/src/content/blog/2023-04/using-buck-to-build-rust-projects.md
+++ b/src/content/blog/2023-04/using-buck-to-build-rust-projects.md
@@ -1,6 +1,9 @@
 ---
 title: Using buck to build Rust projects
 pubDate: 2023-04-13
+series:
+  slug: "buck-rust"
+  order: 1
 ---
 
 A few days ago, Facebook/Meta/idk [announced that buck2 is now open
@@ -31,14 +34,6 @@ this purely for the novelty of trying out some new tech right now. I will
 probably end up with a post giving better motivations at some point in the
 future, but I think it makes more sense once you see how it works, rather than
 starting there.
-
-## A series
-
-This post is part of a series:
-
-* [Using buck to build Rust projects](#) you are here
-* [Using Crates.io with Buck](using-cratesio-with-buck)
-* [Updating Buck](updating-buck)
 
 This post represents how to do this at the time that this was posted; future
 posts may update or change something that happens here. Here's a hopefully

--- a/src/content/blog/2023-04/using-cratesio-with-buck.md
+++ b/src/content/blog/2023-04/using-cratesio-with-buck.md
@@ -1,6 +1,9 @@
 ---
 title: Using Crates.io with Buck
 pubDate: 2023-04-27
+series:
+  slug: "buck-rust"
+  order: 2
 ---
 
 In [a previous post](using-buck-to-build-rust-projects), I laid out the basics
@@ -8,14 +11,6 @@ of building a Rust project with [buck2](https://buck2.build/). We compared and
 contrasted it with Cargo. But what about one of the biggest and best features
 that Cargo has to offer, the ability to use other Rust packages from crates.io?
 They don't use buck, so how can we integrate them into our build?
-
-## A series
-
-This post is part of a series:
-
-* [Using buck to build Rust projects](using-buck-to-build-rust-projects)
-* [Using Crates.io with Buck](#) (you are here)
-* [Updating Buck](updating-buck)
 
 This post represents how to do this at the time that this was posted; future
 posts may update or change something that happens here. Here's a hopefully

--- a/src/content/blog/2023-05/updating-buck.md
+++ b/src/content/blog/2023-05/updating-buck.md
@@ -1,18 +1,14 @@
 ---
 title: Updating Buck
 pubDate: 2023-05-08
+series:
+  slug: "buck-rust"
+  order: 3
 ---
 
 Hey there! A shorter post today, but I wanted to continue my series on Buck
 by going over some things that have changed since this series started.
 
-## A series
-
-This post is part of a series:
-
-* [Using buck to build Rust projects](using-buck-to-build-rust-projects)
-* [Using Crates.io with Buck](using-cratesio-with-buck)
-* [Updating Buck](#) (you are here)
 
 ## Updating Buck
 

--- a/src/data/series.ts
+++ b/src/data/series.ts
@@ -14,4 +14,8 @@ export const series: Record<string, SeriesMetadata> = {
     description:
       "If you truly want to understand technology today, then you should at least be familiar with the philosophy of Gilles Deleuze. Unfortunately for technologists, Deleuze is rooted firmly in a philosophical tradition and a writing style that they probably find opaque. In this blog series, I plan on explaining Deleuze's philosophy in terms that programmers can understand.",
   },
+  "buck-rust": {
+    title: "Using Buck to Build Rust Projects",
+    description: "A guide to using Buck2, Meta's open-source build system, for building Rust projects. Covers the basics, integrating with crates.io, and keeping up with updates.",
+  },
 };


### PR DESCRIPTION
- Add series metadata to frontmatter for all three Buck/Rust posts:
  - using-buck-to-build-rust-projects.md (order: 1)
  - using-cratesio-with-buck.md (order: 2)  
  - updating-buck.md (order: 3)
- Remove hardcoded series sections from post content
- Register 'buck-rust' series in src/data/series.ts with title and description
- Posts now display series navigation component and integrate with series pages

Thanks to @tmfink for noticing that a link was broken! This led me to realizing that when I added the series functinoality, I should have migrated these posts over.