### PR TITLE
Fix link to jj to be on the first mention

### DIFF
--- a/src/content/blog/2025-10/i-see-a-future-in-jj.mdx
+++ b/src/content/blog/2025-10/i-see-a-future-in-jj.mdx
@@ -65,13 +65,13 @@ the rest of the story.
 
 ## Enter jj
 
-For some background, jj is a new version control system (VCS), not a
+For some background, [jj] is a new version control system (VCS), not a
 programming language. It is written in Rust though! While I talked about how I
 decided to get involved with Rust above, my approach here generalizes to other
 kinds of software projects, not just programming languages.
 
 I have a rule of thumb: if [Rain] likes something, I will probably like that
-thing, as we have similar technical tastes. So when I heard her talk about [jj],
+thing, as we have similar technical tastes. So when I heard her talk about jj,
 I put that on my list of things to spend some time with at some point. I was
 especially intrigued because Rain had worked at Meta on their source control
 team. So if she's recommending something related to source control, that's a


### PR DESCRIPTION
In 412f765c0703c1d082a5be59b6558322b4fc7e77 I accidentally introduced a mention of jj before the one I'd linked, so let's make sure the first one is linked.

Thanks @mperham for the report!