### PR TITLE
Remove node version from netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,9 +2,6 @@
   command = "npm run build"
   publish = "dist"
 
-[build.environment]
-  NODE_VERSION = "20"
-
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
Previews were failing, I checked the dashboard and it said we were using the newer versions. But we had the older versions as configuration in-repo. Let's move to that one.