### PR TITLE
Bump remaining outdated deps; enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # One PR for all minor/patch bumps; majors still get individual PRs
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # Node 24's npm 11 matches what edits package-lock.json locally;
+          # npm 10 (Node 22) rejects npm 11-written lockfiles (@emnapi entries)
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
         "@astrojs/react": "^6.0.1",
         "@astrojs/rss": "^4.0.19",
         "@fontsource-variable/literata": "^5.2.8",
-        "@headlessui/react": "^2.1.10",
+        "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.1.3",
         "astro": "^7.0.9",
-        "bluesky-post-embed": "^1.0.5",
+        "bluesky-post-embed": "^1.0.6",
         "markdown-it": "^14.1.1",
         "mdast-util-find-and-replace": "^3.0.2",
-        "sanitize-html": "^2.15.0"
+        "sanitize-html": "^2.17.6"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.20",
@@ -354,30 +354,82 @@
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
+    "node_modules/@atcute/atproto": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@atcute/atproto/-/atproto-3.1.12.tgz",
+      "integrity": "sha512-SaHY0vV5+VfS2ViOcbYtxPmmh82vbxoK5ccHTGn5+ciHNY2arEVcBUFbIQKtsQP4PPZ+lNAVooH+Wh62flvCzg==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/lexicons": "^1.3.1"
+      },
+      "peerDependencies": {
+        "@atcute/lexicons": "^1.0.0"
+      }
+    },
     "node_modules/@atcute/bluesky": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@atcute/bluesky/-/bluesky-1.0.15.tgz",
-      "integrity": "sha512-+EFiybmKQ97aBAgtaD+cKRJER5AMn3cZMkEwEg/pDdWyzxYJ9m1UgemmLdTgI8VrxPufKqdXS2nl7uO7TY6BPA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@atcute/bluesky/-/bluesky-2.1.1.tgz",
+      "integrity": "sha512-wEZfFW58J6yC1SqHcVJOn4qbHENTTzjeCEWthRT5HvKovADLqk54HSMSAuXDMBUbintSTBr0khQNZQ3ZdgzDdQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@atcute/client": "^1.0.0 || ^2.0.0"
+        "@atcute/client": "^3.0.0"
       }
     },
     "node_modules/@atcute/bluesky-richtext-segmenter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@atcute/bluesky-richtext-segmenter/-/bluesky-richtext-segmenter-1.0.5.tgz",
-      "integrity": "sha512-D0FfmJVwppky9naL1OGKcQjtgO0lDLhkG4iCQHpShuHhEZ9FUdf3eUb/eQpVRNJGaJ4ShjEOHA6FlAizcjMkGQ==",
-      "license": "MIT",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@atcute/bluesky-richtext-segmenter/-/bluesky-richtext-segmenter-2.0.4.tgz",
+      "integrity": "sha512-6m5QEAv4lU3qTy5MeJXJRRG33acipYJnMW1T7W/KrMyThGhQ7jSTTh8Z48quElgivgX7MDj6o/ow1oLUsjsCKw==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/bluesky": "^3.2.5",
+        "@atcute/lexicons": "^1.2.2"
+      }
+    },
+    "node_modules/@atcute/bluesky-richtext-segmenter/node_modules/@atcute/bluesky": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@atcute/bluesky/-/bluesky-3.3.5.tgz",
+      "integrity": "sha512-DmzdCQ1VkPRBsIMr79EDxLWLpg0UNWVahFjMelfzau717r+I3ceJm9SxfOK/of+biLOUj4rlr00tNZT+BRe6Ww==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/atproto": "^3.1.12",
+        "@atcute/lexicons": "^1.3.1"
+      },
       "peerDependencies": {
-        "@atcute/bluesky": "^1.0.0",
-        "@atcute/client": "^1.0.0 || ^2.0.0"
+        "@atcute/lexicons": "^1.0.0"
       }
     },
     "node_modules/@atcute/client": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@atcute/client/-/client-2.0.9.tgz",
-      "integrity": "sha512-QNDm9gMP6x9LY77ArwY+urQOBtQW74/onEAz42c40JxRm6Rl9K9cU4ROvNKJ+5cpVmEm1sthEWVRmDr5CSZENA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@atcute/client/-/client-3.1.0.tgz",
+      "integrity": "sha512-+rQPsHXSf0DUm8XoHoaH7Y2E8tIpbsW84djyPj7dqAyrFIjvGuJ1X1DvMufwbTIcmLerdy+dzl34iZcz/h3Vhg==",
       "license": "MIT"
+    },
+    "node_modules/@atcute/lexicons": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@atcute/lexicons/-/lexicons-1.3.1.tgz",
+      "integrity": "sha512-2JVxDmHt+QwsUoPyVYWIN7ZLRLfLx4GeJxKFjA9ofStuby9hCMv7Q4GAPIXuJD8wPv8vrnhr1yRNQhiJX+bthw==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/uint8array": "^1.1.1",
+        "@atcute/util-text": "^1.3.1",
+        "@standard-schema/spec": "^1.1.0",
+        "esm-env": "^1.2.2"
+      }
+    },
+    "node_modules/@atcute/uint8array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@atcute/uint8array/-/uint8array-1.1.4.tgz",
+      "integrity": "sha512-rSW5AFVCIN4ooH7vEZB+J60+uWjn5fRBQAQL58qHLiDm8+xDPmHfEU5GfYOJuuD+7UBj8KKiQugIzohFn8/xPw==",
+      "license": "0BSD"
+    },
+    "node_modules/@atcute/util-text": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@atcute/util-text/-/util-text-1.3.3.tgz",
+      "integrity": "sha512-WhedTmg/msFhrdwXw9RjnNcDl8Vmisxl4+Vzyf5k3+8Gj5TKQg72dLSDtBNmNLd61RbHjgfQRBgE0ez6q/jciw==",
+      "license": "0BSD",
+      "dependencies": {
+        "unicode-segmenter": "^0.14.5"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -936,9 +988,9 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.4.tgz",
-      "integrity": "sha512-lz+OGcAH1dK93rgSMzXmm1qKOJkBUqZf1L4M8TWLNplftQD3IkoEDdUFNfAn4ylsN6WOTVtWaLmvmaHOUk1dTA==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",
@@ -2084,6 +2136,12 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3312,14 +3370,14 @@
       }
     },
     "node_modules/bluesky-post-embed": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bluesky-post-embed/-/bluesky-post-embed-1.0.5.tgz",
-      "integrity": "sha512-xnzbnGIYuLosTN2pXlUh2WcfYn6SBgQk8qfM6L/IxIrIwtJTjNMoPj1iv3dxgl7hK8ItJcBLWTEQuBA/8IpqwQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/bluesky-post-embed/-/bluesky-post-embed-1.0.6.tgz",
+      "integrity": "sha512-gJ+HKQbpDE+Mr7iv72NAF7WRNKu9CsWDwfbdgCtcZruN2HJfAeKHdCk5pflbz1fABwMMInjwN4909HCQjMCY2w==",
       "license": "MIT",
       "dependencies": {
-        "@atcute/bluesky": "^1.0.10",
-        "@atcute/bluesky-richtext-segmenter": "^1.0.5",
-        "@atcute/client": "^2.0.6"
+        "@atcute/bluesky": "^2.1.1",
+        "@atcute/bluesky-richtext-segmenter": "^2.0.4",
+        "@atcute/client": "^3.1.0"
       }
     },
     "node_modules/boolbase": {
@@ -3636,6 +3694,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3887,6 +3951,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
     },
     "node_modules/estree-util-attach-comments": {
       "version": "3.0.0",
@@ -4418,9 +4488,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -4430,10 +4500,92 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -4616,6 +4768,15 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -6780,17 +6941,21 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
-      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "version": "2.17.6",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.6.tgz",
+      "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
+        "htmlparser2": "^12.0.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/sanitize-html/node_modules/escape-string-regexp": {
@@ -7168,6 +7333,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-segmenter": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
+      "integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "@astrojs/react": "^6.0.1",
     "@astrojs/rss": "^4.0.19",
     "@fontsource-variable/literata": "^5.2.8",
-    "@headlessui/react": "^2.1.10",
+    "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.1.3",
     "astro": "^7.0.9",
-    "bluesky-post-embed": "^1.0.5",
+    "bluesky-post-embed": "^1.0.6",
     "markdown-it": "^14.1.1",
     "mdast-util-find-and-replace": "^3.0.2",
-    "sanitize-html": "^2.15.0"
+    "sanitize-html": "^2.17.6"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.20",


### PR DESCRIPTION
@headlessui/react 2.2.10, bluesky-post-embed 1.0.6, sanitize-html 2.17.6 — the last three outdated packages. Dependabot now opens weekly PRs (minor/patch grouped into one) for npm and GitHub Actions, which CI validates, so dependencies stop rotting silently.