### PR TITLE
Don't ship the dev editor's React islands in production builds

### DIFF
--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -70,5 +70,11 @@ const currentSlug = noteSlug(entry.id);
       </ul>
     </aside>
   )}
-  <DevEditorToggle client:only="react" type="note" slug={currentSlug} />
+  {
+    // client:only islands ship the React runtime even when the component
+    // renders null, so only emit the island at all in dev builds.
+    import.meta.env.DEV && (
+      <DevEditorToggle client:only="react" type="note" slug={currentSlug} />
+    )
+  }
 </BaseLayout>

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -52,5 +52,9 @@ const frontmatter = {
       ))}
     </ul>
   </div>
-  <DevCreateButton client:only="react" type="note" />
+  {
+    // client:only islands ship the React runtime even when the component
+    // renders null, so only emit the island at all in dev builds.
+    import.meta.env.DEV && <DevCreateButton client:only="react" type="note" />
+  }
 </BaseLayout>

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -95,5 +95,9 @@ const frontmatter = {
       ))
     }
   </div>
-  <DevCreateButton client:only="react" type="post" />
+  {
+    // client:only islands ship the React runtime even when the component
+    // renders null, so only emit the island at all in dev builds.
+    import.meta.env.DEV && <DevCreateButton client:only="react" type="post" />
+  }
 </BaseLayout>

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -73,5 +73,11 @@ const cleanSlug = entry.id.replace(/^\d{4}-\d{2}\//, '');
       )
     }
   </article>
-  <DevEditorToggle client:only="react" type="post" slug={cleanSlug} />
+  {
+    // client:only islands ship the React runtime even when the component
+    // renders null, so only emit the island at all in dev builds.
+    import.meta.env.DEV && (
+      <DevEditorToggle client:only="react" type="post" slug={cleanSlug} />
+    )
+  }
 </BaseLayout>


### PR DESCRIPTION
## Summary

`DevCreateButton`/`DevEditorToggle` correctly render `null` in production, but mounting them with `client:only="react"` still emits an `<astro-island>` and loads the React client runtime (**~177KB**, `client.*.js`) on every post page, note page, and both listing pages — ~230 pages downloading and hydrating React to render nothing.

This gates the islands behind `import.meta.env.DEV` in the four templates, so production builds emit no islands (and therefore no React) at all.

## Verification

- Dist diff against a trunk baseline build: all 231 affected pages differ **only** by the deleted island markup (checked programmatically — every diff opcode is a deletion containing the island runtime/element; zero unexplained edits).
- `grep -rl 'astro-island' dist --include='*.html'` → 0 files after the change.
- Dev smoke test: `npm run dev` still renders the editor island on `/writing/` and `/__editor/posts` responds 200.
- `astro check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)