### PR TITLE
Add SEO meta tags, sitemap, robots.txt, and a 404 page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
+import sitemap from "@astrojs/sitemap";
 import { unified } from "@astrojs/markdown-remark";
 import tailwindcss from "@tailwindcss/vite";
 import remarkWikiLinks from "./src/plugins/remarkWikiLinks.ts";
@@ -14,7 +15,7 @@ export default defineConfig({
   // space between adjacent inline elements (nav links, dates) in rendered
   // text. Keep the old whitespace-collapsing behavior instead.
   compressHTML: true,
-  integrations: [mdx(), react()],
+  integrations: [mdx(), react(), sitemap()],
   server: {
     host: true,
     port: 4321,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/mdx": "^7.0.3",
         "@astrojs/react": "^6.0.1",
         "@astrojs/rss": "^4.0.19",
+        "@astrojs/sitemap": "^3.7.3",
         "@fontsource-variable/literata": "^5.2.8",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.1.3",
@@ -438,6 +439,17 @@
       "dependencies": {
         "fast-xml-parser": "^5.5.7",
         "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
         "zod": "^4.3.6"
       }
     },
@@ -1057,7 +1069,6 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -2550,27 +2561,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,
@@ -2848,7 +2838,6 @@
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -2872,6 +2861,15 @@
       "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -3147,6 +3145,12 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -7665,6 +7669,40 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
@@ -7704,6 +7742,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -7970,7 +8014,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-segmenter": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@astrojs/mdx": "^7.0.3",
     "@astrojs/react": "^6.0.1",
     "@astrojs/rss": "^4.0.19",
+    "@astrojs/sitemap": "^3.7.3",
     "@fontsource-variable/literata": "^5.2.8",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.1.3",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://steveklabnik.com/sitemap-index.xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 const { frontmatter, section } = Astro.props;
 const description =
   frontmatter.description || "Steve Klabnik's personal website and blog";
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <html lang="en">
@@ -23,13 +24,27 @@ const description =
     <meta charset="utf-8" />
 
     <link rel="icon" href="/favicon.ico" sizes="any" /><!-- 32×32 -->
-    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" /><!-- 180×180 -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalURL} />
+    <meta property="og:type" content={frontmatter.pubDate ? "article" : "website"} />
+    <meta property="og:title" content={frontmatter.pageTitle} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:site_name" content="Steve Klabnik" />
+    {
+      frontmatter.pubDate && (
+        <meta
+          property="article:published_time"
+          content={frontmatter.pubDate.toISOString()}
+        />
+      )
+    }
+    <meta name="twitter:card" content="summary" />
     <meta name="darkreader-lock" />
     <meta name="color-scheme" content="light dark" />
     <link

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+
+const frontmatter = {
+  pageTitle: "Page not found - Steve Klabnik",
+  description: "This page doesn't exist.",
+};
+---
+
+<BaseLayout frontmatter={frontmatter}>
+  <div class="prose prose-slate dark:prose-invert">
+    <h1>Page not found</h1>
+    <p>Sorry, there's nothing at this URL.</p>
+    <p>
+      You might be looking for something in my <a href="/writing">writing</a>,
+      or you can head back to the <a href="/">home page</a>.
+    </p>
+  </div>
+</BaseLayout>

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -33,7 +33,9 @@ if (entry.data.series?.slug) {
 
 const frontmatter = {
   pageTitle: entry.data.title,
-  description: `Blog post: ${entry.data.title} by Steve Klabnik`,
+  description:
+    entry.data.description ?? `Blog post: ${entry.data.title} by Steve Klabnik`,
+  pubDate: entry.data.pubDate,
 };
 
 const cleanSlug = entry.id.replace(/^\d{4}-\d{2}\//, '');


### PR DESCRIPTION
## Summary

The site had no canonical URLs, no Open Graph/Twitter Card tags, no sitemap, and no 404 page. This adds all of them:

- **Canonical + Open Graph + Twitter Card tags** in `BaseLayout`. Posts get `og:type=article` and `article:published_time`; other pages get `og:type=website`. There's no `og:image` since the site has no images — `twitter:card=summary` renders a text-only preview card, which works fine without one. (A default site og:image could be added later if wanted.)
- **Post meta descriptions** now use the post's `description` frontmatter when present (matching what the RSS feed already does) instead of always the generic `Blog post: … by Steve Klabnik` fallback. No current posts set it, so no output changes today.
- **Sitemap** via `@astrojs/sitemap` (`/sitemap-index.xml`, 248 URLs) plus a **robots.txt** pointing at it.
- **404 page** — Netlify serves `dist/404.html` automatically instead of its generic error page.
- **Removes the `/icon.svg` favicon link** — the file doesn't exist, so every page load 404'd on it.

## Verification

- `astro check` and `astro build` pass (249 pages incl. the 404).
- Spot-checked built HTML: post pages carry the full article meta set with correct canonical URLs; homepage is `og:type=website`; sitemap excludes the 404 page; zero remaining `icon.svg` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)