### PR TITLE
Fix two latent date bugs: local-time year grouping, series latest post

### DIFF
--- a/src/pages/topics/[slug].astro
+++ b/src/pages/topics/[slug].astro
@@ -24,7 +24,8 @@ const { posts, metadata, slug } = Astro.props;
 // Group posts by year (same pattern as writing.astro)
 let postsByYear: Record<string, CollectionEntry<"blog">[]> = {};
 posts.forEach((post) => {
-  const year = new Date(post.data.pubDate).getFullYear().toString();
+  // UTC to match how dates are displayed (see writing.astro)
+  const year = post.data.pubDate.getUTCFullYear().toString();
   if (!postsByYear[year]) postsByYear[year] = [];
   postsByYear[year].push(post);
 });

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -21,7 +21,10 @@ seriesData.forEach((_, slug) => {
 let allPostsByDate = (() => {
   let posts: Record<string, Array<CollectionEntry<"blog">>> = {};
   allPosts.map((post) => {
-    let year = new Date(post.data.pubDate).getFullYear();
+    // pubDate parses as UTC midnight and is displayed with timeZone: "UTC"
+    // everywhere, so group by UTC year too (local time is a day early in
+    // negative-offset timezones).
+    let year = post.data.pubDate.getUTCFullYear();
     let array = posts[year.toString()];
 
     // if this is the first post of this year, we have to create the inner array

--- a/src/utils/series.ts
+++ b/src/utils/series.ts
@@ -104,7 +104,11 @@ export function getAllSeriesWithMetadata(
         ...metadata,
         posts,
         postCount: posts.length,
-        latestPost: posts[posts.length - 1],
+        // posts is sorted by series order, which doesn't have to match
+        // chronology; "latest" means newest by publication date.
+        latestPost: posts.reduce((latest, post) =>
+          post.data.pubDate > latest.data.pubDate ? post : latest
+        ),
         firstPost: posts[0]
       });
     }


### PR DESCRIPTION
## Summary

- **Year grouping used the build machine's local timezone.** The year headings on `/writing` and `/topics/*` bucketed posts with `getFullYear()`, while every displayed date uses `timeZone: 'UTC'`. Since `pubDate` parses as UTC midnight, building in any negative-offset timezone files a post published early on Jan 1 under the previous year's heading. Now uses `getUTCFullYear()`.
- **A series' "latest post" was the highest-`order` post, not the newest.** `latestPost` drives the "last updated" date on `/series` and the series ordering on the homepage, but was computed as the last post after sorting by series `order` — only correct while `order` happens to match chronology. Now picks the newest post by `pubDate`.

## Verification

Neither bug bites with today's content (CI builds in UTC; all current series are in chronological order), and a dist diff against trunk confirms **zero output changes** — the only differing bytes in the whole build were a live Bluesky embed's like count ticking up. `astro check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)