### PR TITLE
Code health: shared post utils, dead code, fresher wikilink slugs

### DIFF
--- a/src/components/Link.jsx
+++ b/src/components/Link.jsx
@@ -1,6 +1,0 @@
-// Additional link styling (underline, visited color) lives in global.css
-export default function Link({ text, href }) {
-  return (
-    <a className="text-blue-500" href={href}>{ text }</a>
-  )
-}

--- a/src/components/SeriesNavigation.astro
+++ b/src/components/SeriesNavigation.astro
@@ -1,9 +1,9 @@
 ---
 import { getSeriesMetadata } from '../utils/series';
 import type { SeriesNavigation as SeriesNavigationType } from '../utils/series';
+import { postSlug } from '../utils/posts';
 
 export interface Props {
-  currentPost: any;
   seriesData: SeriesNavigationType;
 }
 
@@ -34,7 +34,7 @@ if (!seriesMetadata) {
     <div class="flex-1 min-w-0">
       {seriesData.prev ? (
         <a
-          href={`/writing/${seriesData.prev.id.replace(/^\d{4}-\d{2}\//, '')}`}
+          href={`/writing/${postSlug(seriesData.prev.id)}`}
           class="text-sm text-accent hover:underline inline-flex items-start gap-1 group"
         >
           <span class="shrink-0 group-hover:translate-x-[-2px] transition-transform">←</span>
@@ -48,7 +48,7 @@ if (!seriesMetadata) {
     <div class="flex-1 min-w-0 sm:text-right">
       {seriesData.next ? (
         <a
-          href={`/writing/${seriesData.next.id.replace(/^\d{4}-\d{2}\//, '')}`}
+          href={`/writing/${postSlug(seriesData.next.id)}`}
           class="text-sm text-accent hover:underline inline-flex items-start gap-1 sm:justify-end group"
         >
           <span class="break-words line-clamp-2 sm:text-right">{seriesData.next.data.title}</span>

--- a/src/components/editor/CreateNoteModal.tsx
+++ b/src/components/editor/CreateNoteModal.tsx
@@ -27,8 +27,8 @@ export default function CreateNoteModal({ open, onClose }: Props) {
     try {
       const result = await createNote(title.trim());
       window.location.href = `/notes/${result.slug}/`;
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
       setCreating(false);
     }
   }

--- a/src/components/editor/CreatePostModal.tsx
+++ b/src/components/editor/CreatePostModal.tsx
@@ -35,8 +35,8 @@ export default function CreatePostModal({ open, onClose }: Props) {
         slug: slug || undefined,
       });
       window.location.href = `/writing/${result.slug}/`;
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
       setCreating(false);
     }
   }

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -4,6 +4,7 @@ import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { getContainerRenderer as getMDXRenderer } from "@astrojs/mdx";
 import { loadRenderers } from "astro:container";
 import type { APIContext } from "astro";
+import { postSlug, sortByDateDesc } from "../utils/posts";
 
 export async function getStaticPaths() {
   return [{ params: {} }];
@@ -34,20 +35,18 @@ export async function GET(context: APIContext) {
   const posts = await getCollection("blog");
 
   const items = await Promise.all(
-    posts
-      .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
-      .map(async (post) => {
-        const { Content } = await render(post);
-        const content = await container.renderToString(Content);
+    sortByDateDesc(posts).map(async (post) => {
+      const { Content } = await render(post);
+      const content = await container.renderToString(Content);
 
-        return {
-          title: post.data.title,
-          pubDate: post.data.pubDate,
-          description: post.data.description ?? excerpt(content),
-          link: `/writing/${post.id.replace(/^\d{4}-\d{2}\//, '')}/`,
-          content,
-        };
-      }),
+      return {
+        title: post.data.title,
+        pubDate: post.data.pubDate,
+        description: post.data.description ?? excerpt(content),
+        link: `/writing/${postSlug(post.id)}/`,
+        content,
+      };
+    }),
   );
 
   return rss({

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import { getCollection } from "astro:content";
 import { getRecentTopics, getTopicMetadata } from "../utils/topics.ts";
 import { buildSeriesData, getAllSeriesWithMetadata } from "../utils/series.ts";
-import { noteSlug } from "../utils/notes";
+import { formatDate, postSlug, sortByDateDesc } from "../utils/posts.ts";
 
 const allPosts = await getCollection("blog");
 const allNotes = await getCollection("notes");
@@ -12,9 +12,7 @@ const allNotes = await getCollection("notes");
 const recentTopics = getRecentTopics(allPosts, 5);
 
 // Recent blog posts (last 5)
-const recentPosts = [...allPosts]
-  .sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
-  .slice(0, 5);
+const recentPosts = sortByDateDesc(allPosts).slice(0, 5);
 
 // Series data
 const seriesData = buildSeriesData(allPosts);
@@ -90,7 +88,7 @@ const frontmatter = {
               <li class="pl-6 relative">
                 <span class="absolute left-0 top-2 w-2 h-2 bg-accent-muted rounded-full" />
                 <a
-                  href={`/writing/${post.id.replace(/^\d{4}-\d{2}\//, "")}/`}
+                  href={`/writing/${postSlug(post.id)}/`}
                   class="text-accent hover:text-accent-hover visited:text-accent-visited font-medium"
                 >
                   {post.data.title}
@@ -106,12 +104,7 @@ const frontmatter = {
                   </span>
                 )}
                 <time class="block text-sm text-secondary mt-1">
-                  {post.data.pubDate.toLocaleDateString("en-US", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                    timeZone: "UTC",
-                  })}
+                  {formatDate(post.data.pubDate)}
                 </time>
               </li>
             );

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { buildBacklinks, noteSlug } from "../../utils/notes";
 import type { Backlink } from "../../utils/notes";
+import { formatDate } from "../../utils/posts";
 import DevEditorToggle from "../../components/editor/DevEditorToggle";
 
 export async function getStaticPaths() {
@@ -40,12 +41,7 @@ const currentSlug = noteSlug(entry.id);
       <p class="text-sm text-secondary mt-0">
         Last updated{" "}
         <time datetime={entry.data.lastUpdated.toISOString()}>
-          {entry.data.lastUpdated.toLocaleDateString("en-US", {
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-            timeZone: "UTC",
-          })}
+          {formatDate(entry.data.lastUpdated)}
         </time>
       </p>
     )}

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getCollection } from "astro:content";
 import { noteSlug } from "../../utils/notes";
+import { formatDate } from "../../utils/posts";
 import DevCreateButton from "../../components/editor/DevCreateButton";
 
 const pageTitle = "Notes";
@@ -40,12 +41,7 @@ const frontmatter = {
           </a>
           {note.data.lastUpdated && (
             <time class="block text-sm text-secondary mt-1">
-              Updated {note.data.lastUpdated.toLocaleDateString("en-US", {
-                year: "numeric",
-                month: "short",
-                day: "numeric",
-                timeZone: "UTC",
-              })}
+              Updated {formatDate(note.data.lastUpdated)}
             </time>
           )}
         </li>

--- a/src/pages/series/[slug].astro
+++ b/src/pages/series/[slug].astro
@@ -4,6 +4,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { buildSeriesData, getSeriesMetadata } from "../../utils/series.ts";
 import type { CollectionEntry } from "astro:content";
 import type { SeriesMetadata } from "../../utils/series.ts";
+import { formatDate, postSlug } from "../../utils/posts.ts";
 
 export async function getStaticPaths() {
   const allPosts = await getCollection("blog");
@@ -64,12 +65,12 @@ const frontmatter = {
           <div class="flex items-start justify-between">
             <div class="flex-1">
               <h3 class="mt-0 mb-1">
-                <a href={`/writing/${post.id.replace(/^\d{4}-\d{2}\//, '')}`} class="no-underline hover:underline">
+                <a href={`/writing/${postSlug(post.id)}`} class="no-underline hover:underline">
                   {post.data.title}
                 </a>
               </h3>
               <p class="text-sm text-secondary m-0">
-                Part {index + 1} • {post.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}
+                Part {index + 1} • {formatDate(post.data.pubDate)}
               </p>
             </div>
           </div>

--- a/src/pages/series/index.astro
+++ b/src/pages/series/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { buildSeriesData, getAllSeriesWithMetadata } from "../../utils/series.ts";
+import { formatDate } from "../../utils/posts.ts";
 
 const allPosts = await getCollection("blog");
 const seriesData = buildSeriesData(allPosts);
@@ -38,7 +39,7 @@ const frontmatter = {
             <div class="flex items-center gap-4 text-sm text-muted">
               <span>{series.postCount} posts</span>
               <span>•</span>
-              <span>Last updated: {series.latestPost.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}</span>
+              <span>Last updated: {formatDate(series.latestPost.data.pubDate)}</span>
             </div>
           </article>
         ))}

--- a/src/pages/topics/[slug].astro
+++ b/src/pages/topics/[slug].astro
@@ -4,6 +4,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { topics } from "../../data/topics.ts";
 import { getPostsByTopic } from "../../utils/topics.ts";
 import { getSeriesMetadata } from "../../utils/series.ts";
+import { formatDate, postSlug } from "../../utils/posts.ts";
 import type { CollectionEntry } from "astro:content";
 
 export async function getStaticPaths() {
@@ -24,7 +25,7 @@ const { posts, metadata, slug } = Astro.props;
 // Group posts by year (same pattern as writing.astro)
 let postsByYear: Record<string, CollectionEntry<"blog">[]> = {};
 posts.forEach((post) => {
-  // UTC to match how dates are displayed (see writing.astro)
+  // UTC to match how formatDate displays dates
   const year = post.data.pubDate.getUTCFullYear().toString();
   if (!postsByYear[year]) postsByYear[year] = [];
   postsByYear[year].push(post);
@@ -56,7 +57,7 @@ const frontmatter = {
                 <li class="pl-6 relative">
                   <span class="absolute left-0 top-2 w-2 h-2 bg-accent-muted rounded-full"></span>
                   <a
-                    href={`/writing/${post.id.replace(/^\d{4}-\d{2}\//, '')}/`}
+                    href={`/writing/${postSlug(post.id)}/`}
                     class="text-accent hover:text-accent-hover visited:text-accent-visited font-medium"
                   >
                     {post.data.title}
@@ -72,7 +73,7 @@ const frontmatter = {
                     </span>
                   )}
                   <time class="block text-sm text-secondary mt-1">
-                    {post.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}
+                    {formatDate(post.data.pubDate)}
                   </time>
                 </li>
               );

--- a/src/pages/topics/index.astro
+++ b/src/pages/topics/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getPostsByTopic, getAllTopicsWithMetadata } from "../../utils/topics.ts";
+import { formatDate } from "../../utils/posts.ts";
 
 const allPosts = await getCollection("blog");
 const topicData = getPostsByTopic(allPosts);
@@ -28,9 +29,7 @@ const frontmatter = {
             <span>{topic.postCount} posts</span>
             <span>&middot;</span>
             <span>
-              Latest: {topic.latestPost.data.pubDate.toLocaleDateString('en-US', {
-                year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'
-              })}
+              Latest: {formatDate(topic.latestPost.data.pubDate)}
             </span>
           </div>
         </a>

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -4,6 +4,7 @@ import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
 import { buildSeriesData, getSeriesMetadata } from "../utils/series.ts";
 import { getTopicMetadata } from "../utils/topics.ts";
+import { formatDate, postSlug } from "../utils/posts.ts";
 import DevCreateButton from "../components/editor/DevCreateButton";
 const pageTitle = "Steve Klabnik's Blog";
 const allPosts = await getCollection("blog");
@@ -64,7 +65,7 @@ const frontmatter = {
               return (
                 <li class="pl-6 relative">
                   <span class="absolute left-0 top-2 w-2 h-2 bg-accent-muted rounded-full"></span>
-                  <a href={`/writing/${post.id.replace(/^\d{4}-\d{2}\//, '')}/`} class="text-accent hover:text-accent-hover visited:text-accent-visited font-medium">
+                  <a href={`/writing/${postSlug(post.id)}/`} class="text-accent hover:text-accent-hover visited:text-accent-visited font-medium">
                     {post.data.title}
                   </a>
                   {series && post.data.series && (
@@ -88,7 +89,7 @@ const frontmatter = {
                     </span>
                   )}
                   <time class="block text-sm text-secondary mt-1">
-                    {post.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}
+                    {formatDate(post.data.pubDate)}
                   </time>
                 </li>
               );

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -5,18 +5,15 @@ import SeriesNavigationComponent from "../../components/SeriesNavigation.astro";
 import { buildSeriesData, getSeriesNavigation } from "../../utils/series";
 import type { SeriesNavigation } from "../../utils/series.ts";
 import { getTopicMetadata } from "../../utils/topics.ts";
+import { formatDate, postSlug } from "../../utils/posts.ts";
 import DevEditorToggle from "../../components/editor/DevEditorToggle";
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection("blog");
-  return blogEntries.map((entry) => {
-    // Remove the date folder prefix (e.g., "2020-01/") from the id
-    const cleanSlug = entry.id.replace(/^\d{4}-\d{2}\//, '');
-    return {
-      params: { slug: cleanSlug },
-      props: { entry },
-    };
-  });
+  return blogEntries.map((entry) => ({
+    params: { slug: postSlug(entry.id) },
+    props: { entry },
+  }));
 }
 
 const { entry } = Astro.props;
@@ -38,14 +35,14 @@ const frontmatter = {
   pubDate: entry.data.pubDate,
 };
 
-const cleanSlug = entry.id.replace(/^\d{4}-\d{2}\//, '');
+const cleanSlug = postSlug(entry.id);
 ---
 
 <BaseLayout frontmatter={frontmatter}>
   <article class="prose prose-slate dark:prose-invert">
     <h1 class="mb-2">{entry.data.title}</h1>
     <time datetime={entry.data.pubDate.toISOString()} class="text-secondary">
-      {entry.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}
+      {formatDate(entry.data.pubDate)}
     </time>
     {entry.data.topic && getTopicMetadata(entry.data.topic) && (
       <div class="mt-2">
@@ -57,23 +54,9 @@ const cleanSlug = entry.id.replace(/^\d{4}-\d{2}\//, '');
         </a>
       </div>
     )}
-    {
-      seriesNavigation && (
-        <SeriesNavigationComponent
-          currentPost={entry}
-          seriesData={seriesNavigation}
-        />
-      )
-    }
+    {seriesNavigation && <SeriesNavigationComponent seriesData={seriesNavigation} />}
     <Content />
-    {
-      seriesNavigation && (
-        <SeriesNavigationComponent
-          currentPost={entry}
-          seriesData={seriesNavigation}
-        />
-      )
-    }
+    {seriesNavigation && <SeriesNavigationComponent seriesData={seriesNavigation} />}
   </article>
   {
     // client:only islands ship the React runtime even when the component

--- a/src/plugins/remarkWikiLinks.ts
+++ b/src/plugins/remarkWikiLinks.ts
@@ -22,9 +22,10 @@ function getExistingNoteSlugs(): Set<string> {
 }
 
 export default function remarkWikiLinks() {
-  const existingSlugs = getExistingNoteSlugs();
-
   return (tree: Root) => {
+    // Read per document rather than at plugin init, so notes created or
+    // deleted while the dev server runs are reflected without a restart.
+    const existingSlugs = getExistingNoteSlugs();
     findAndReplace(tree, [
       [
         wikiLinkRegex,

--- a/src/plugins/viteEditorApi.ts
+++ b/src/plugins/viteEditorApi.ts
@@ -1,6 +1,7 @@
 import type { Plugin, ViteDevServer } from "vite";
 import fs from "node:fs";
 import path from "node:path";
+import { slugify } from "../utils/wikilinks";
 
 const NOTES_DIR = path.resolve("src/content/notes");
 const BLOG_DIR = path.resolve("src/content/blog");
@@ -256,13 +257,7 @@ function saveNote(
 }
 
 function createNote(data: { title: string; slug?: string }): Response {
-  const slug =
-    data.slug ??
-    data.title
-      .toLowerCase()
-      .trim()
-      .replace(/\s+/g, "-")
-      .replace(/[^\w-]/g, "");
+  const slug = data.slug ?? slugify(data.title);
   if (!isSafeSlug(slug)) return jsonResponse({ error: "Invalid slug" }, 400);
   const filePath = path.join(NOTES_DIR, `${slug}.md`);
   if (fs.existsSync(filePath)) {
@@ -344,13 +339,7 @@ function createPost(data: {
   series?: { slug: string; order: number } | null;
   topic?: string | null;
 }): Response {
-  const slug =
-    data.slug ??
-    data.title
-      .toLowerCase()
-      .trim()
-      .replace(/\s+/g, "-")
-      .replace(/[^\w-]/g, "");
+  const slug = data.slug ?? slugify(data.title);
   if (!isSafeSlug(slug)) return jsonResponse({ error: "Invalid slug" }, 400);
 
   const date = new Date(data.pubDate);

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,0 +1,31 @@
+import type { CollectionEntry } from "astro:content";
+
+/**
+ * Blog entry ids include their date folder (e.g. "2020-01/some-post");
+ * URLs don't. Strip the prefix to get the slug used in /writing/ links.
+ */
+export function postSlug(id: string): string {
+  return id.replace(/^\d{4}-\d{2}\//, "");
+}
+
+/**
+ * The site-wide date format ("Jan 5, 2026"). UTC, because pubDate and
+ * lastUpdated parse as UTC midnight.
+ */
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** Returns a copy of the posts sorted newest first. */
+export function sortByDateDesc(
+  posts: CollectionEntry<"blog">[],
+): CollectionEntry<"blog">[] {
+  return [...posts].sort(
+    (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
+  );
+}

--- a/src/utils/topics.ts
+++ b/src/utils/topics.ts
@@ -1,5 +1,6 @@
 import { topics } from '../data/topics.ts';
 import type { CollectionEntry } from 'astro:content';
+import { sortByDateDesc } from './posts.ts';
 
 export interface TopicMetadata {
   title: string;
@@ -38,8 +39,8 @@ export function getPostsByTopic(
   }
 
   // Sort posts within each topic by date (newest first)
-  topicMap.forEach((posts) => {
-    posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
+  topicMap.forEach((posts, topic) => {
+    topicMap.set(topic, sortByDateDesc(posts));
   });
 
   return topicMap;


### PR DESCRIPTION
## Summary

Pure refactor — no output changes (verified, see below).

- **New `src/utils/posts.ts`** with `postSlug()` (the `YYYY-MM/` prefix strip that was inlined in 8 files), `formatDate()` (the `toLocaleDateString` options object duplicated in 9 places), and `sortByDateDesc()` — now used everywhere.
- **`remarkWikiLinks` reads note slugs per document** instead of once at plugin init, so notes created/deleted while the dev server runs get correct missing-link styling without a restart.
- **Editor API reuses `slugify()`** from `utils/wikilinks` instead of two inlined copies, so editor-created note filenames and wikilink resolution can't drift apart.
- **Delete dead `Link.jsx`** (imported nowhere); its `text-blue-500` was the only class it contributed to the generated CSS.
- Drop `SeriesNavigation`'s unused `currentPost: any` prop, the unused `noteSlug` import in `index.astro`, and two `catch (e: any)`s in the editor modals.

## Verification

- `astro check` (0 errors) and `astro build` pass.
- **Dist diff against trunk: byte-identical** across all 249 pages except (a) the CSS file's content hash changed because the dead `.text-blue-500` rule dropped out, and (b) a live Bluesky embed's repost counter ticked 20→21 between builds. Nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)