### PR TITLE
Fix WCAG contrast for Bluesky embed links

### DIFF
--- a/src/components/BlueskyPost.astro
+++ b/src/components/BlueskyPost.astro
@@ -27,7 +27,8 @@ const render = renderPost(data);
     --max-feed-height: 600px;
     --text-primary: #000000;
     --text-secondary: #455668;
-    --text-link: #1083fe;
+    /* Bluesky's brand blue (#1083fe) is only 3.68:1 on white; WCAG AA needs 4.5:1 */
+    --text-link: #0168d5;
     --background-primary: #ffffff;
     --background-secondary: #455668;
     --divider-hover: #a9b7c5;
@@ -41,7 +42,7 @@ const render = renderPost(data);
   :where(.dark, .dark *) .bluesky-embed {
     --text-primary: #f1f3f5;
     --text-secondary: #aebbc9;
-    --text-link: #1083fe;
+    --text-link: #208bfe;
     --background-primary: #161e27;
     --background-secondary: #212d3b;
     --divider: #2e4052;


### PR DESCRIPTION
Lighthouse flagged the Bluesky embed on posts: its brand-blue links (#1083fe) are 3.68:1 against white, below the 4.5:1 WCAG AA minimum, dropping post pages to 92 on accessibility.

- **Light mode:** override `--text-link` to `#0168d5` (5.33:1) — the embed's own button-hover blue, so it stays in palette.
- **Dark mode:** bump `--text-link` to `#208bfe` (4.95:1) instead of scraping by at 4.56:1.

Upstream (`bluesky-post-embed@1.0.6`) has no fix — latest release is the repo tip. Verified locally: Lighthouse accessibility 92 → 96 on the DIDs post; remaining points are the embed's unnamed avatar link, which needs an upstream markup fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)