### PR TITLE
Implement standard.site: publish posts as AT Protocol records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,14 @@ This is an Astro static site for steveklabnik.com with the following structure:
 - Static site generation with no server-side rendering
 - RSS feed generated at `/feed.xml` (`src/pages/feed.xml.ts`, renders full post content via the Container API)
 
+### Standard.site (AT Protocol)
+- The site publishes [standard.site](https://standard.site) lexicon records (`site.standard.publication` + one `site.standard.document` per post) to Steve's PDS
+- Config (DID, AT-URI helpers, publication record) lives in `src/data/standardSite.ts`; document rkeys are the post slugs, so AT-URIs are derived at build time
+- The build emits a sync manifest at `/standard-site.json` (`src/pages/standard-site.json.ts`) with the desired state of every record
+- Sync runs **automatically after every production deploy** via a local Netlify build plugin (`plugins/netlify-standard-site/`, `onSuccess` hook); it needs `STANDARD_SITE_APP_PASSWORD` (a Bluesky app password) set in the Netlify environment, and skips deploy previews/branch deploys
+- `npm run sync:standard-site` (`scripts/standard-site-sync.mjs`) is the same sync run manually: `--dry-run` needs no auth; `--prune` deletes records for removed posts (deliberately never passed in CI)
+- Verification: `public/.well-known/site.standard.publication` returns the publication AT-URI, and each post page gets a `<link rel="site.standard.document">` tag via `BaseLayout`
+
 ### Styling
 - Tailwind CSS 4 via `@tailwindcss/vite`; global styles and theme variables in `/src/styles/global.css`
 - Legacy JS config (`tailwind.config.js`) is bridged in with `@config` and holds the typography plugin customizations

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,12 +2,23 @@
   command = "npm run build"
   publish = "dist"
 
+# Post-deploy: sync standard.site records to the PDS (production only).
+[[plugins]]
+  package = "./plugins/netlify-standard-site"
+
 [[headers]]
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
+
+# Extensionless files are served as octet-stream by default; the
+# standard.site verification endpoint should read as plain text.
+[[headers]]
+  for = "/.well-known/site.standard.publication"
+  [headers.values]
+    Content-Type = "text/plain; charset=utf-8"
 
 # Astro asset filenames are content-hashed, so they can be cached forever.
 [[headers]]

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "astro build",
     "check": "astro check",
     "preview": "astro preview",
+    "sync:standard-site": "node scripts/standard-site-sync.mjs",
     "astro": "astro"
   },
   "dependencies": {

--- a/plugins/netlify-standard-site/index.js
+++ b/plugins/netlify-standard-site/index.js
@@ -1,0 +1,47 @@
+/**
+ * Runs after a successful production deploy: syncs standard.site records to
+ * the PDS so they always match the live site (see
+ * scripts/standard-site-sync.mjs). onSuccess fires after the deploy is
+ * live, which is the ordering the records need — they should only ever
+ * describe pages that are actually up.
+ *
+ * Deliberately does not pass --prune: a manifest-generation bug would turn
+ * every record into an orphan and mass-delete them. Removing records for
+ * deleted posts stays a manual `npm run sync:standard-site -- --prune`.
+ */
+import { execFileSync } from "node:child_process";
+
+export const onSuccess = ({ utils, constants }) => {
+  if (process.env.CONTEXT !== "production") {
+    console.log(
+      `Skipping standard.site sync (context: ${process.env.CONTEXT ?? "unknown"}).`,
+    );
+    return;
+  }
+
+  if (!process.env.STANDARD_SITE_APP_PASSWORD) {
+    utils.status.show({
+      title: "standard.site sync skipped",
+      summary:
+        "STANDARD_SITE_APP_PASSWORD is not set in the Netlify environment, " +
+        "so PDS records were not updated for this deploy.",
+    });
+    return;
+  }
+
+  try {
+    execFileSync(
+      "node",
+      [
+        "scripts/standard-site-sync.mjs",
+        "--source",
+        `${constants.PUBLISH_DIR}/standard-site.json`,
+      ],
+      { stdio: "inherit" },
+    );
+  } catch (error) {
+    // The deploy is already live; fail the plugin so the miss is visible
+    // in the build log without rolling anything back.
+    utils.build.failPlugin("standard.site sync failed", { error });
+  }
+};

--- a/plugins/netlify-standard-site/manifest.yml
+++ b/plugins/netlify-standard-site/manifest.yml
@@ -1,0 +1,1 @@
+name: netlify-standard-site

--- a/plugins/netlify-standard-site/package.json
+++ b/plugins/netlify-standard-site/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "netlify-standard-site",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/public/.well-known/site.standard.publication
+++ b/public/.well-known/site.standard.publication
@@ -1,0 +1,1 @@
+at://did:plc:3danwc67lo7obz2fmdg6jxcr/site.standard.publication/self

--- a/scripts/standard-site-sync.mjs
+++ b/scripts/standard-site-sync.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Syncs standard.site (https://standard.site) records to the PDS.
+ *
+ * Reads the manifest the site build emits at /standard-site.json (the
+ * desired state of the site.standard.publication and site.standard.document
+ * records) and diffs it against what's in the repo, then creates/updates
+ * whatever changed. Run it after deploying, so records always describe
+ * pages that are actually live.
+ *
+ * Usage:
+ *   node scripts/standard-site-sync.mjs --dry-run     # diff only, no auth needed
+ *   STANDARD_SITE_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
+ *   node scripts/standard-site-sync.mjs               # apply changes
+ *
+ * Flags:
+ *   --source <url|file>  Manifest location. Defaults to the live site;
+ *                        pass dist/standard-site.json to sync a local build.
+ *   --dry-run            Print the plan without writing to the PDS.
+ *   --prune              Delete records for posts no longer in the manifest.
+ */
+
+import { readFile } from "node:fs/promises";
+
+const SITE = "https://steveklabnik.com";
+const IDENTIFIER = process.env.STANDARD_SITE_IDENTIFIER ?? "steveklabnik.com";
+const ICON_URL = `${SITE}/icon-512.png`;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const prune = args.includes("--prune");
+const sourceIdx = args.indexOf("--source");
+const source =
+  sourceIdx !== -1 ? args[sourceIdx + 1] : `${SITE}/standard-site.json`;
+
+async function fetchJson(url, init) {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new Error(`${init?.method ?? "GET"} ${url}: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function loadManifest() {
+  if (/^https?:\/\//.test(source)) return fetchJson(source);
+  return JSON.parse(await readFile(source, "utf8"));
+}
+
+async function resolvePds(did) {
+  const doc = await fetchJson(`https://plc.directory/${did}`);
+  const pds = doc.service?.find((s) => s.id === "#atproto_pds")?.serviceEndpoint;
+  if (!pds) throw new Error(`No PDS endpoint in DID document for ${did}`);
+  return pds;
+}
+
+async function listRecords(pds, did, collection) {
+  const records = new Map();
+  let cursor;
+  do {
+    const url = new URL(`${pds}/xrpc/com.atproto.repo.listRecords`);
+    url.searchParams.set("repo", did);
+    url.searchParams.set("collection", collection);
+    url.searchParams.set("limit", "100");
+    if (cursor) url.searchParams.set("cursor", cursor);
+    const page = await fetchJson(url);
+    for (const record of page.records) {
+      records.set(record.uri.split("/").pop(), record.value);
+    }
+    cursor = page.records.length > 0 ? page.cursor : undefined;
+  } while (cursor);
+  return records;
+}
+
+/** JSON.stringify with sorted keys, for order-insensitive comparison. */
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const entries = Object.keys(value)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+const changed = (a, b) => canonical(a) !== canonical(b);
+
+async function createSession(pds) {
+  const password = process.env.STANDARD_SITE_APP_PASSWORD;
+  if (!password) {
+    throw new Error(
+      "STANDARD_SITE_APP_PASSWORD is not set. Create an app password at " +
+        "https://bsky.app/settings/app-passwords (no chat access needed), " +
+        "or use --dry-run to preview without writing.",
+    );
+  }
+  return fetchJson(`${pds}/xrpc/com.atproto.server.createSession`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ identifier: IDENTIFIER, password }),
+  });
+}
+
+async function main() {
+  const manifest = await loadManifest();
+  const { did } = manifest;
+  const pds = await resolvePds(did);
+  console.log(`Repo ${did} on ${pds}`);
+
+  // Reads are public, so the whole plan is computed without auth.
+  const existingDocs = await listRecords(pds, did, "site.standard.document");
+  const existingPubs = await listRecords(pds, did, "site.standard.publication");
+  const existingPub = existingPubs.get(manifest.publication.rkey);
+
+  const publicationValue = { ...manifest.publication.value };
+  // Blobs are uploaded, not declared, so the manifest has no icon; keep
+  // whatever icon the live record already carries.
+  if (existingPub?.icon) publicationValue.icon = existingPub.icon;
+
+  const plan = [];
+  if (!existingPub) {
+    plan.push({ action: "create", collection: "site.standard.publication", rkey: manifest.publication.rkey, value: publicationValue, uploadIcon: true });
+  } else if (changed(publicationValue, existingPub)) {
+    plan.push({ action: "update", collection: "site.standard.publication", rkey: manifest.publication.rkey, value: publicationValue });
+  }
+
+  for (const [rkey, value] of Object.entries(manifest.documents)) {
+    const existing = existingDocs.get(rkey);
+    if (!existing) {
+      plan.push({ action: "create", collection: "site.standard.document", rkey, value });
+    } else if (changed(value, existing)) {
+      plan.push({ action: "update", collection: "site.standard.document", rkey, value });
+    }
+  }
+
+  const orphans = [...existingDocs.keys()].filter((rkey) => !(rkey in manifest.documents));
+  if (prune) {
+    for (const rkey of orphans) {
+      plan.push({ action: "delete", collection: "site.standard.document", rkey });
+    }
+  }
+
+  const total = Object.keys(manifest.documents).length;
+  // +1 for the publication record; deletes aren't part of the desired set.
+  const unchanged = total + 1 - plan.filter((op) => op.action !== "delete").length;
+  console.log(`${total} documents in manifest; ${unchanged} records unchanged`);
+  for (const op of plan) {
+    console.log(`  ${op.action} ${op.collection}/${op.rkey}`);
+  }
+  if (orphans.length > 0 && !prune) {
+    console.log(`  ${orphans.length} record(s) on the PDS but not in the manifest (use --prune to delete): ${orphans.join(", ")}`);
+  }
+  if (plan.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+  if (dryRun) {
+    console.log("Dry run; no changes made.");
+    return;
+  }
+
+  const session = await createSession(pds);
+  const authed = { Authorization: `Bearer ${session.accessJwt}` };
+
+  for (const op of plan) {
+    if (op.action === "delete") {
+      await fetchJson(`${pds}/xrpc/com.atproto.repo.deleteRecord`, {
+        method: "POST",
+        headers: { ...authed, "Content-Type": "application/json" },
+        body: JSON.stringify({ repo: did, collection: op.collection, rkey: op.rkey }),
+      });
+    } else {
+      if (op.uploadIcon) {
+        const icon = await fetch(ICON_URL);
+        if (icon.ok) {
+          const upload = await fetchJson(`${pds}/xrpc/com.atproto.repo.uploadBlob`, {
+            method: "POST",
+            headers: { ...authed, "Content-Type": icon.headers.get("content-type") ?? "image/png" },
+            body: await icon.arrayBuffer(),
+          });
+          op.value.icon = upload.blob;
+        } else {
+          console.warn(`Could not fetch ${ICON_URL} (${icon.status}); creating publication without an icon.`);
+        }
+      }
+      await fetchJson(`${pds}/xrpc/com.atproto.repo.putRecord`, {
+        method: "POST",
+        headers: { ...authed, "Content-Type": "application/json" },
+        body: JSON.stringify({ repo: did, collection: op.collection, rkey: op.rkey, record: op.value }),
+      });
+    }
+    console.log(`  done: ${op.action} ${op.collection}/${op.rkey}`);
+  }
+  console.log(`Applied ${plan.length} change(s).`);
+}
+
+main().catch((err) => {
+  console.error(err.message ?? err);
+  process.exit(1);
+});

--- a/src/data/standardSite.ts
+++ b/src/data/standardSite.ts
@@ -1,0 +1,57 @@
+/**
+ * Standard.site (https://standard.site) configuration: AT Protocol lexicon
+ * records that mirror this site's content into Steve's PDS.
+ *
+ * The publication record lives at a fixed "self" rkey, and each blog post's
+ * document record uses the post slug as its rkey, so every AT-URI is
+ * derivable at build time without a lookup table. The sync script
+ * (scripts/standard-site-sync.mjs) reads /standard-site.json from the built
+ * site and upserts these records to the PDS.
+ */
+
+export const DID = "did:plc:3danwc67lo7obz2fmdg6jxcr";
+
+export const PUBLICATION_COLLECTION = "site.standard.publication";
+export const DOCUMENT_COLLECTION = "site.standard.document";
+
+export const PUBLICATION_RKEY = "self";
+
+export const PUBLICATION_AT_URI = `at://${DID}/${PUBLICATION_COLLECTION}/${PUBLICATION_RKEY}`;
+
+export function documentAtUri(slug: string): string {
+  return `at://${DID}/${DOCUMENT_COLLECTION}/${slug}`;
+}
+
+/**
+ * Record keys allow a subset of characters; post slugs are used as rkeys
+ * directly, so anything outside this alphabet can't get a document record.
+ * https://atproto.com/specs/record-key
+ */
+export function isValidRkey(slug: string): boolean {
+  return /^[A-Za-z0-9._~-]{1,512}$/.test(slug) && slug !== "." && slug !== "..";
+}
+
+/**
+ * The site.standard.publication record value. The `icon` blob is added by
+ * the sync script (blobs have to be uploaded, not declared), so it isn't
+ * part of the build-time value. Colors mirror the light theme in global.css.
+ */
+export const PUBLICATION_RECORD = {
+  $type: PUBLICATION_COLLECTION,
+  url: "https://steveklabnik.com",
+  name: "Steve Klabnik",
+  description: "Steve Klabnik's personal website and blog",
+  basicTheme: {
+    $type: "site.standard.theme.basic",
+    // --color-bg #faf5ff
+    background: { $type: "site.standard.theme.color#rgb", r: 250, g: 245, b: 255 },
+    // --color-text #1e293b
+    foreground: { $type: "site.standard.theme.color#rgb", r: 30, g: 41, b: 59 },
+    // --color-accent #6525c4
+    accent: { $type: "site.standard.theme.color#rgb", r: 101, g: 37, b: 196 },
+    accentForeground: { $type: "site.standard.theme.color#rgb", r: 255, g: 255, b: 255 },
+  },
+  preferences: {
+    showInDiscover: true,
+  },
+};

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import { ClientRouter } from "astro:transitions";
 import ThemeToggle from "../components/ThemeToggle.astro";
+import { PUBLICATION_AT_URI } from "../data/standardSite";
 
 const { frontmatter, section } = Astro.props;
 const description =
@@ -53,6 +54,13 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       title="Steve Klabnik"
       href="https://steveklabnik.com/feed.xml"
     />
+    <!-- Standard.site (AT Protocol) discovery hint and per-document verification -->
+    <link rel="site.standard.publication" href={PUBLICATION_AT_URI} />
+    {
+      frontmatter.documentAtUri && (
+        <link rel="site.standard.document" href={frontmatter.documentAtUri} />
+      )
+    }
     <title>{frontmatter.pageTitle}</title>
   </head>
   <body data-section={section}>

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -4,28 +4,10 @@ import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { getContainerRenderer as getMDXRenderer } from "@astrojs/mdx";
 import { loadRenderers } from "astro:container";
 import type { APIContext } from "astro";
-import { postSlug, sortByDateDesc } from "../utils/posts";
+import { excerpt, postSlug, sortByDateDesc } from "../utils/posts";
 
 export async function getStaticPaths() {
   return [{ params: {} }];
-}
-
-/**
- * Plain-text excerpt of rendered post HTML, for feed readers that show
- * summaries instead of the full content.
- */
-function excerpt(html: string, maxLength = 280): string {
-  const text = html
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;|&#34;/g, '"')
-    .replace(/&#x27;|&#39;/g, "'")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (text.length <= maxLength) return text;
-  return text.slice(0, text.lastIndexOf(" ", maxLength)) + "…";
 }
 
 export async function GET(context: APIContext) {

--- a/src/pages/standard-site.json.ts
+++ b/src/pages/standard-site.json.ts
@@ -1,0 +1,57 @@
+import { getCollection, render } from "astro:content";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getContainerRenderer as getMDXRenderer } from "@astrojs/mdx";
+import { loadRenderers } from "astro:container";
+import { excerpt, htmlToText, postSlug, sortByDateDesc } from "../utils/posts";
+import {
+  DID,
+  DOCUMENT_COLLECTION,
+  PUBLICATION_AT_URI,
+  PUBLICATION_RECORD,
+  PUBLICATION_RKEY,
+  isValidRkey,
+} from "../data/standardSite";
+
+export async function getStaticPaths() {
+  return [{ params: {} }];
+}
+
+/**
+ * Standard.site sync manifest: the desired state of Steve's
+ * site.standard.* records, keyed by rkey. Consumed by
+ * scripts/standard-site-sync.mjs, which diffs it against the PDS.
+ */
+export async function GET() {
+  const renderers = await loadRenderers([getMDXRenderer()]);
+  const container = await AstroContainer.create({ renderers });
+
+  const posts = await getCollection("blog");
+
+  const documents: Record<string, object> = {};
+  for (const post of sortByDateDesc(posts)) {
+    const slug = postSlug(post.id);
+    // Slugs double as record keys; anything outside the rkey alphabet
+    // can't be synced. No current post trips this.
+    if (!isValidRkey(slug)) continue;
+
+    const { Content } = await render(post);
+    const html = await container.renderToString(Content);
+
+    documents[slug] = {
+      $type: DOCUMENT_COLLECTION,
+      site: PUBLICATION_AT_URI,
+      path: `/writing/${slug}/`,
+      title: post.data.title,
+      description: post.data.description ?? excerpt(html),
+      textContent: htmlToText(html),
+      ...(post.data.topic ? { tags: [post.data.topic] } : {}),
+      publishedAt: post.data.pubDate.toISOString(),
+    };
+  }
+
+  return Response.json({
+    did: DID,
+    publication: { rkey: PUBLICATION_RKEY, value: PUBLICATION_RECORD },
+    documents,
+  });
+}

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -6,6 +6,7 @@ import { buildSeriesData, getSeriesNavigation } from "../../utils/series";
 import type { SeriesNavigation } from "../../utils/series.ts";
 import { getTopicMetadata } from "../../utils/topics.ts";
 import { formatDate, postSlug } from "../../utils/posts.ts";
+import { documentAtUri, isValidRkey } from "../../data/standardSite";
 import DevEditorToggle from "../../components/editor/DevEditorToggle";
 
 export async function getStaticPaths() {
@@ -28,14 +29,16 @@ if (entry.data.series?.slug) {
   seriesNavigation = getSeriesNavigation(entry, seriesData);
 }
 
+const cleanSlug = postSlug(entry.id);
+
 const frontmatter = {
   pageTitle: entry.data.title,
   description:
     entry.data.description ?? `Blog post: ${entry.data.title} by Steve Klabnik`,
   pubDate: entry.data.pubDate,
+  // Standard.site verification: ties this page to its AT Protocol record.
+  documentAtUri: isValidRkey(cleanSlug) ? documentAtUri(cleanSlug) : undefined,
 };
-
-const cleanSlug = postSlug(entry.id);
 ---
 
 <BaseLayout frontmatter={frontmatter}>

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -21,6 +21,30 @@ export function formatDate(date: Date): string {
   });
 }
 
+/** Plain-text rendering of post HTML: tags stripped, entities decoded. */
+export function htmlToText(html: string): string {
+  return html
+    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;|&#34;/g, '"')
+    .replace(/&#x27;|&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Plain-text excerpt of rendered post HTML, for feed readers and record
+ * descriptions that show summaries instead of the full content.
+ */
+export function excerpt(html: string, maxLength = 280): string {
+  const text = htmlToText(html);
+  if (text.length <= maxLength) return text;
+  return text.slice(0, text.lastIndexOf(" ", maxLength)) + "…";
+}
+
 /** Returns a copy of the posts sorted newest first. */
 export function sortByDateDesc(
   posts: CollectionEntry<"blog">[],


### PR DESCRIPTION
Mirrors the blog into [standard.site](https://standard.site) lexicon records (`site.standard.publication` + one `site.standard.document` per post) on my PDS, so AT Protocol readers and indexes (Leaflet, pckt, docs.surf, …) can discover, subscribe to, and recommend posts.

## Design

- **Slugs are rkeys.** All 229 post slugs are valid AT record keys, so every AT-URI is derivable at build time — no lookup table. The publication lives at the fixed rkey `self`.
- **The build emits the desired state.** `/standard-site.json` renders every post through the same Container API pipeline as the RSS feed (MDX, wikilinks, and embeds handled), producing the full record values including `textContent`. The feed's excerpt/HTML-stripping logic moved to `src/utils/posts.ts` and is shared.
- **Sync is a diff.** `scripts/standard-site-sync.mjs` (zero deps) compares the manifest against the PDS and writes only what changed. `--dry-run` needs no auth (reads are public); `--prune` removes records for deleted posts and is deliberately manual-only.
- **Deploys sync automatically.** A local Netlify plugin (`onSuccess`, production context only) runs the sync after the deploy is live, so records never point at pages that aren't up. Missing `STANDARD_SITE_APP_PASSWORD` shows a "sync skipped" deploy status; a sync failure fails the plugin visibly without affecting the deploy.

## Verification

- `.well-known/site.standard.publication` returns the publication AT-URI (with a `text/plain` header via netlify.toml)
- every page gets `<link rel="site.standard.publication">`; post pages also get `<link rel="site.standard.document">`

## Tested

- build + `astro check` clean; feed output unchanged after the excerpt refactor
- dry-run against the real PDS plans the expected 230 creates
- all three plugin paths exercised (preview skip, missing password, 401 → failPlugin)

After merge: set `STANDARD_SITE_APP_PASSWORD` in the Netlify environment; the first production deploy creates all 230 records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)